### PR TITLE
Update trunk.lua

### DIFF
--- a/config/trunk.lua
+++ b/config/trunk.lua
@@ -16,7 +16,7 @@ Config.Trunk = {
 		0,  -- Utility
 		50, -- Vans
 		1,  -- Cycles
-		20, -- Boats
+		50, -- Boats
 		10, -- Helicopters
 		10, -- Planes
 		0,  -- Service
@@ -35,7 +35,7 @@ Config.Trunk = {
 		['dubsta3'] = 35,
 		['kamacho'] = 35,
 		['guardian'] = 20,
-
+		['bison'] = 20,
 		['bifta'] = 3,
 		['teslax'] = 16,
 		['minivan'] = 30,
@@ -44,14 +44,14 @@ Config.Trunk = {
 		['superkart'] = 0,
 
 		-- Motorcycles
-		['bagger'] = 6,
+		['bagger'] = 5,
 
 		-- ATV's
-		['blazer'] = 3,
-		['blazer2'] = 3,
-		['blazer3'] = 3,
-		['blazer4'] = 3,
-		['blazer5'] = 3,
+		['blazer'] = 0,
+		['blazer2'] = 0,
+		['blazer3'] = 0,
+		['blazer4'] = 0,
+		['blazer5'] = 0,
 
 		-- Boats
 		['seashark'] = 3,
@@ -59,7 +59,7 @@ Config.Trunk = {
 		['dinghy2'] = 10,
 		['tropic'] = 10,
 		['marquis'] = 30,
-		['yacht2'] = 60,
+		['yacht2'] = 150,
 		['submersible'] = 3,
 	}
 }


### PR DESCRIPTION
Changed ATV storage 3 > 0
Added ['bison'] = 35
Changed ['bagger'] 6 -> 5
> This change only allows one gun to be stored in the vehicle instead of two. This is to counter 2 ARs being stored.

Boat base storage value increased from 20 -> 50
['yacht2'] storage value increased to 150