### PR TITLE
Update trunk.lua

### DIFF
--- a/config/trunk.lua
+++ b/config/trunk.lua
@@ -35,7 +35,7 @@ Config.Trunk = {
 		['dubsta3'] = 35,
 		['kamacho'] = 35,
 		['guardian'] = 20,
-		['bison'] = 20,
+		['bison'] = 35,
 		['bifta'] = 3,
 		['teslax'] = 16,
 		['minivan'] = 30,
@@ -58,7 +58,7 @@ Config.Trunk = {
 		['suntrap'] = 10,
 		['dinghy2'] = 10,
 		['tropic'] = 10,
-		['marquis'] = 30,
+		['marquis'] = 75,
 		['yacht2'] = 150,
 		['submersible'] = 3,
 	}


### PR DESCRIPTION
> ['bison'] changed 20 > 35. Previous merge wasn't implemented.

> ['marquis'] = increase from 30 > 75. As a boat/yacht of this size and speed it should have a storage capacity of 75. Community was indecisive on 50 or 75 storage but majority was in favor of 75.