### PR TITLE
Update trunk.lua

### DIFF
--- a/config/trunk.lua
+++ b/config/trunk.lua
@@ -58,7 +58,7 @@ Config.Trunk = {
 		['suntrap'] = 10,
 		['dinghy2'] = 10,
 		['tropic'] = 10,
-		['marquis'] = 75,
+		['marquis'] = 100,
 		['yacht2'] = 150,
 		['submersible'] = 3,
 	}


### PR DESCRIPTION
> ['marquis'] = 75 > 100,

Due to popular demand by community. Marquis yacht should have storage capacity of 100. 
Trade offs of the current boat stats validate a higher storage capacity.